### PR TITLE
Rc v2.0.2

### DIFF
--- a/harvest.py
+++ b/harvest.py
@@ -101,13 +101,17 @@ class Harvest(object):
             return location
         return location.replace(Harvest.CLIENTS_URL + '/', '')
 
-    def get_projects(self):
+    def get_projects(self, client_id=None):
         """Retrieves all projects
 
         :return: Projects
         :rtype: dict
         """
-        return self.get_request(self.base_url + Harvest.PROJECTS_URL)
+        if client_id is None:
+            return self.get_request(self.base_url + Harvest.PROJECTS_URL)
+        else:
+            return self.get_request(self.base_url + Harvest.PROJECTS_URL +
+                                    '?client=' + str(client_id))
 
     def get_project(self, project_id):
         """Retrieves project by ID
@@ -119,33 +123,41 @@ class Harvest(object):
         return self.get_request(
             self.base_url + Harvest.PROJECTS_URL + '/' + project_id)
 
-    def get_project_by_name(self, name):
+    def get_project_by_name(self, name, client_name):
         """Retrieves project by name
 
         :param name: Name of project
         :return: Project
         :rtype: dict
         """
-        projects = self.get_projects()
+        client = self.get_client_by_name(client_name)
+        projects = self.get_projects(client[Harvest.CLIENT][Harvest.ID])
         if projects:
             for project in projects:
                 if project[Harvest.PROJECT][Harvest.NAME] == name:
                     return project
         return None
 
-    def get_project_by_prefix(self, prefix):
+    def get_project_by_prefix(self, prefix, client_name):
         """Retrieves project by prefix
 
         :param name: Prefix of project
+        :param name: Client name / company appreviation
         :return: Project
         :rtype: dict
         """
-        projects = self.get_projects()
-        if projects:
-            for project in projects:
-                if project[Harvest.PROJECT][Harvest.NAME].startswith( prefix ):
-                    return project
-        return None
+        client = self.get_client_by_name(client_name)
+        if client:
+            projects = self.get_projects(client[Harvest.CLIENT][Harvest.ID])
+            if projects:
+                for project in projects:
+                    if project[Harvest.PROJECT][Harvest.NAME].startswith(
+                            prefix):
+                        return project
+            else:
+                return None
+        else:
+            return None
 
     def get_todays_updated_projects(self):
         """Retrieves projects that have been updated today.

--- a/harvest.py
+++ b/harvest.py
@@ -133,6 +133,20 @@ class Harvest(object):
                     return project
         return None
 
+    def get_project_by_prefix(self, prefix):
+        """Retrieves project by prefix
+
+        :param name: Prefix of project
+        :return: Project
+        :rtype: dict
+        """
+        projects = self.get_projects()
+        if projects:
+            for project in projects:
+                if project[Harvest.PROJECT][Harvest.NAME].startswith( prefix ):
+                    return project
+        return None
+
     def get_todays_updated_projects(self):
         """Retrieves projects that have been updated today.
 

--- a/manage.py
+++ b/manage.py
@@ -66,5 +66,6 @@ def setup_db(recreate=False):
             'manage.py:create_tables() failed, insert_projects aborted.')
         session.close()
 
+
 if __name__ == '__main__':
     manager.run()

--- a/webhook.py
+++ b/webhook.py
@@ -163,33 +163,32 @@ class TeamworkHandler(object):
                 if new_company_abbr != company_abbr:
                     new_project_name = self.update_project_name(project_name, new_company_abbr,
                                                                 tw_project_id)
+                    # Update Harvest project
+                    project_prefix = self.get_project_prefix(
+                        company_abbr, tw_project_id)
+                    new_h_client = self.harvest.get_client_by_name(new_company_abbr)
+                    h_project = self.harvest.get_project_by_prefix(
+                        project_prefix, company_abbr)
+                    if h_project:
+                        h_client = self.harvest.get_client_by_name(company_abbr)
+                        if h_client:
+                            self.harvest.update_project(h_project[Harvest.PROJECT][Harvest.ID],
+                                                        new_project_name,
+                                                        new_h_client[Harvest.CLIENT][Harvest.ID])
+                            self.update_project_users(new_company_abbr, tw_project_id)
+                            app.logger.debug('Updating Harvest project name ' + project_name +
+                                                ' to new name ' + new_project_name)
+                        else:
+                            app.logger.error('Could not update Harvest project because Client ' +
+                                            company_abbr + ' does not exist.')
+                    else:
+                        app.logger.error('Could not update Harvest project because matching Project name ' +
+                                        project_name + ' does not exist')
                 else:
                     # Do nothing otherwise run into an infinite loop situation
                     app.logger.debug(
                         'Project company does not need to be updated ' +
                         company_abbr)
-
-                # Update Harvest project
-                project_prefix = self.get_project_prefix(
-                    company_abbr, tw_project_id)
-                new_h_client = self.harvest.get_client_by_name(new_company_abbr)
-                h_project = self.harvest.get_project_by_prefix(
-                    project_prefix, company_abbr)
-                if h_project:
-                    h_client = self.harvest.get_client_by_name(company_abbr)
-                    if h_client:
-                        self.harvest.update_project(h_project[Harvest.PROJECT][Harvest.ID],
-                                                    new_project_name,
-                                                    new_h_client[Harvest.CLIENT][Harvest.ID])
-                        self.update_project_users(new_company_abbr, tw_project_id)
-                        app.logger.debug('Updating Harvest project name ' + project_name +
-                                            ' to new name ' + new_project_name)
-                    else:
-                        app.logger.error('Could not update Harvest project because Client ' +
-                                        company_abbr + ' does not exist.')
-                else:
-                    app.logger.error('Could not update Harvest project because matching Project name ' +                    project_name +
-                                        ' does not exist')
 
     def update_project_name(self, project_name, company_abbr, tw_project_id):
         """Update the project name in TeamworkPM and Harvest

--- a/webhook.py
+++ b/webhook.py
@@ -172,6 +172,7 @@ class TeamworkHandler(object):
                 # Update Harvest project
                 project_prefix = self.get_project_prefix(
                     company_abbr, tw_project_id)
+                new_h_client = self.harvest.get_client_by_name(new_company_abbr)
                 h_project = self.harvest.get_project_by_prefix(
                     project_prefix, company_abbr)
                 if h_project:
@@ -179,15 +180,16 @@ class TeamworkHandler(object):
                     if h_client:
                         self.harvest.update_project(h_project[Harvest.PROJECT][Harvest.ID],
                                                     new_project_name,
-                                                    h_client[Harvest.CLIENT][Harvest.ID])
+                                                    new_h_client[Harvest.CLIENT][Harvest.ID])
+                        self.update_project_users(new_company_abbr, tw_project_id)
                         app.logger.debug('Updating Harvest project name ' + project_name +
-                                         ' to new name ' + new_project_name)
+                                            ' to new name ' + new_project_name)
                     else:
-                        app.logger.error('Could not update Harvest project because Client ' + company_abbr +
-                                         ' does not exist.')
+                        app.logger.error('Could not update Harvest project because Client ' +
+                                        company_abbr + ' does not exist.')
                 else:
-                    app.logger.error('Could not update Harvest project because matching Project name ' + project_name +
-                                     ' does not exist')
+                    app.logger.error('Could not update Harvest project because matching Project name ' +                    project_name +
+                                        ' does not exist')
 
     def update_project_name(self, project_name, company_abbr, tw_project_id):
         """Update the project name in TeamworkPM and Harvest

--- a/webhook.py
+++ b/webhook.py
@@ -149,7 +149,8 @@ class TeamworkHandler(object):
                 new_project_name = self.add_project_prefix(project_name, new_company_abbr,
                                                            tw_project_id)
                 # Update Teamwork project
-                self.update_project_name(new_project_name, new_company_abbr, tw_project_id)
+                self.update_project_name(
+                    new_project_name, new_company_abbr, tw_project_id)
                 app.logger.debug(
                     'Project schema appended to name ' +
                     new_project_name)
@@ -169,22 +170,24 @@ class TeamworkHandler(object):
                         company_abbr)
 
                 # Update Harvest project
-                project_prefix = self.get_project_prefix(company_abbr, tw_project_id)
-                h_project = self.harvest.get_project_by_prefix(project_prefix)
+                project_prefix = self.get_project_prefix(
+                    company_abbr, tw_project_id)
+                h_project = self.harvest.get_project_by_prefix(
+                    project_prefix, company_abbr)
                 if h_project:
                     h_client = self.harvest.get_client_by_name(company_abbr)
                     if h_client:
                         self.harvest.update_project(h_project[Harvest.PROJECT][Harvest.ID],
                                                     new_project_name,
                                                     h_client[Harvest.CLIENT][Harvest.ID])
-                        app.logger.debug( 'Updating Harvest project name ' + project_name +
-                        ' to new name ' + new_project_name)
+                        app.logger.debug('Updating Harvest project name ' + project_name +
+                                         ' to new name ' + new_project_name)
                     else:
                         app.logger.error('Could not update Harvest project because Client ' + company_abbr +
-                                        ' does not exist.')
+                                         ' does not exist.')
                 else:
                     app.logger.error('Could not update Harvest project because matching Project name ' + project_name +
-                                    ' does not exist')
+                                     ' does not exist')
 
     def update_project_name(self, project_name, company_abbr, tw_project_id):
         """Update the project name in TeamworkPM and Harvest
@@ -210,15 +213,16 @@ class TeamworkHandler(object):
 
         # Update Harvest project
         project_prefix = self.get_project_prefix(company_abbr, tw_project_id)
-        h_project = self.harvest.get_project_by_prefix(project_prefix)
+        h_project = self.harvest.get_project_by_prefix(
+            project_prefix, company_abbr)
         if h_project:
             h_client = self.harvest.get_client_by_name(company_abbr)
             if h_client:
                 self.harvest.update_project(h_project[Harvest.PROJECT][Harvest.ID],
                                             new_project_name,
                                             h_client[Harvest.CLIENT][Harvest.ID])
-                app.logger.debug( 'Updating Harvest project name ' + project_name +
-                ' to new name ' + new_project_name)
+                app.logger.debug('Updating Harvest project name ' + project_name +
+                                 ' to new name ' + new_project_name)
             else:
                 app.logger.error('Could not update Harvest project because Client ' + company_abbr +
                                  ' does not exist.')
@@ -238,8 +242,10 @@ class TeamworkHandler(object):
         app.logger.debug('Teamwork assigned people: ' + str(tw_emails))
 
         try:
-            project_prefix = self.get_project_prefix(company_abbr , tw_project_id)
-            h_project = self.harvest.get_project_by_prefix(project_prefix)
+            project_prefix = self.get_project_prefix(
+                company_abbr, tw_project_id)
+            h_project = self.harvest.get_project_by_prefix(
+                project_prefix, company_abbr)
             if h_project is not None:
                 h_project_id = h_project[Harvest.PROJECT][Harvest.ID]
                 h_project_name = h_project[Harvest.PROJECT][Harvest.NAME]
@@ -365,8 +371,10 @@ class TeamworkHandler(object):
             self.teamwork.update_project(new_project_name, tw_project_id)
 
             # Check to see if Harvest project already exists first.
-            project_prefix = self.get_project_prefix(company_abbr , tw_project_id)
-            h_project = self.harvest.get_project_by_prefix(project_prefix)
+            project_prefix = self.get_project_prefix(
+                company_abbr, tw_project_id)
+            h_project = self.harvest.get_project_by_prefix(
+                project_prefix, company_abbr)
             if h_project:
                 app.logger.error('Harvest project name ' + new_project_name +
                                  ' already exist. Project not created in Harvest.')
@@ -378,14 +386,14 @@ class TeamworkHandler(object):
                         new_project_name, h_client[
                             Harvest.CLIENT][
                             Harvest.ID])
-                    app.logger.debug('Harvest project created: ' + new_project_name)
+                    app.logger.debug(
+                        'Harvest project created: ' +
+                        new_project_name)
                 else:
                     app.logger.error(
                         'Could not Create Harvest project because Client ' +
                         company_abbr +
                         ' does not exist.')
-
-
 
     def add_project_prefix(self, project_name, company_abbr,
                            tw_project_id, project_date=None, project_number=None):
@@ -410,7 +418,7 @@ class TeamworkHandler(object):
         return project_name
 
     def get_project_prefix(self, company_abbr,
-                            tw_project_id, project_date=None, project_number=None):
+                           tw_project_id, project_date=None, project_number=None):
         """Adds the project prefix to the project name
 
         :param project_name: Project name

--- a/webhook.py
+++ b/webhook.py
@@ -149,10 +149,12 @@ class TeamworkHandler(object):
                 new_project_name = self.add_project_prefix(project_name, new_company_abbr,
                                                            tw_project_id)
                 # Update Teamwork project
-                self.teamwork.update_project(new_project_name, tw_project_id)
+                self.update_project_name(new_project_name, new_company_abbr, tw_project_id)
                 app.logger.debug(
                     'Project schema appended to name ' +
                     new_project_name)
+
+                self.update_project_users(new_company_abbr, tw_project_id)
             else:
                 new_project_name = project_name
                 company_abbr = re.sub("^[0-9]{4}-", "", project_name)
@@ -163,13 +165,26 @@ class TeamworkHandler(object):
                 else:
                     # Do nothing otherwise run into an infinite loop situation
                     app.logger.debug(
-                        'Project name does not need to be updated ' +
-                        project_name)
+                        'Project company does not need to be updated ' +
+                        company_abbr)
 
-            self.update_project_users(
-                new_project_name, tw_project[
-                    Teamwork.PROJECT][
-                    Teamwork.ID])
+                # Update Harvest project
+                project_prefix = self.get_project_prefix(company_abbr, tw_project_id)
+                h_project = self.harvest.get_project_by_prefix(project_prefix)
+                if h_project:
+                    h_client = self.harvest.get_client_by_name(company_abbr)
+                    if h_client:
+                        self.harvest.update_project(h_project[Harvest.PROJECT][Harvest.ID],
+                                                    new_project_name,
+                                                    h_client[Harvest.CLIENT][Harvest.ID])
+                        app.logger.debug( 'Updating Harvest project name ' + project_name +
+                        ' to new name ' + new_project_name)
+                    else:
+                        app.logger.error('Could not update Harvest project because Client ' + company_abbr +
+                                        ' does not exist.')
+                else:
+                    app.logger.error('Could not update Harvest project because matching Project name ' + project_name +
+                                    ' does not exist')
 
     def update_project_name(self, project_name, company_abbr, tw_project_id):
         """Update the project name in TeamworkPM and Harvest
@@ -185,7 +200,7 @@ class TeamworkHandler(object):
         new_project_name = self.add_project_prefix(
             postfix_project_name, company_abbr, tw_project_id, project_date)
         app.logger.debug(
-            'Updating project name ' +
+            'Updating Teamwork project name ' +
             project_name +
             ' to new name ' +
             new_project_name)
@@ -194,13 +209,16 @@ class TeamworkHandler(object):
         self.teamwork.update_project(new_project_name, tw_project_id)
 
         # Update Harvest project
-        h_project = self.harvest.get_project_by_name(project_name)
+        project_prefix = self.get_project_prefix(company_abbr, tw_project_id)
+        h_project = self.harvest.get_project_by_prefix(project_prefix)
         if h_project:
             h_client = self.harvest.get_client_by_name(company_abbr)
             if h_client:
                 self.harvest.update_project(h_project[Harvest.PROJECT][Harvest.ID],
                                             new_project_name,
                                             h_client[Harvest.CLIENT][Harvest.ID])
+                app.logger.debug( 'Updating Harvest project name ' + project_name +
+                ' to new name ' + new_project_name)
             else:
                 app.logger.error('Could not update Harvest project because Client ' + company_abbr +
                                  ' does not exist.')
@@ -210,19 +228,21 @@ class TeamworkHandler(object):
 
         return new_project_name
 
-    def update_project_users(self, project_name, tw_project_id):
+    def update_project_users(self, company_abbr, tw_project_id):
         """Update the project users
 
-        :param project_name: Project name
+        :param company_abbr: Company Appreviation
         :param tw_project_id: TeamworkPM project ID
         """
         tw_emails = self.get_tw_project_emails(tw_project_id)
         app.logger.debug('Teamwork assigned people: ' + str(tw_emails))
 
         try:
-            h_project = self.harvest.get_project_by_name(project_name)
+            project_prefix = self.get_project_prefix(company_abbr , tw_project_id)
+            h_project = self.harvest.get_project_by_prefix(project_prefix)
             if h_project is not None:
                 h_project_id = h_project[Harvest.PROJECT][Harvest.ID]
+                h_project_name = h_project[Harvest.PROJECT][Harvest.NAME]
                 h_emails = self.get_h_project_emails(h_project_id)
                 app.logger.debug('Harvest assigned people: ' + str(h_emails))
 
@@ -255,14 +275,14 @@ class TeamworkHandler(object):
 
                 app.logger.debug(
                     'Adding people to project "' +
-                    project_name +
+                    h_project_name +
                     '" ' +
                     str(add_people))
                 for person_id in add_people:
                     self.harvest.add_user_assignment(h_project_id, person_id)
                 app.logger.debug(
                     'Removing people from project "' +
-                    project_name +
+                    h_project_name +
                     '" ' +
                     str(remove_people))
                 for person_id in remove_people:
@@ -271,11 +291,11 @@ class TeamworkHandler(object):
             else:
                 app.logger.error(
                     'Harvest project does not exist ' +
-                    project_name)
+                    project_prefix)
         except KeyError:
             app.logger.exception(
-                'Could not update project users for project name ' +
-                project_name)
+                'Could not update project users for project prefix ' +
+                project_prefix)
 
     def get_tw_project_emails(self, project_id):
         """Get a list of assigned emails to the given project
@@ -344,18 +364,28 @@ class TeamworkHandler(object):
                 project_name, company_abbr, tw_project_id)
             self.teamwork.update_project(new_project_name, tw_project_id)
 
-            # Create Harvest project
-            h_client = self.harvest.get_client_by_name(company_abbr)
-            if h_client:
-                self.harvest.create_project(
-                    new_project_name, h_client[
-                        Harvest.CLIENT][
-                        Harvest.ID])
+            # Check to see if Harvest project already exists first.
+            project_prefix = self.get_project_prefix(company_abbr , tw_project_id)
+            h_project = self.harvest.get_project_by_prefix(project_prefix)
+            if h_project:
+                app.logger.error('Harvest project name ' + new_project_name +
+                                 ' already exist. Project not created in Harvest.')
             else:
-                app.logger.error(
-                    'Could not Create Harvest project because Client ' +
-                    company_abbr +
-                    ' does not exist.')
+                # Create Harvest project
+                h_client = self.harvest.get_client_by_name(company_abbr)
+                if h_client:
+                    self.harvest.create_project(
+                        new_project_name, h_client[
+                            Harvest.CLIENT][
+                            Harvest.ID])
+                    app.logger.debug('Harvest project created: ' + new_project_name)
+                else:
+                    app.logger.error(
+                        'Could not Create Harvest project because Client ' +
+                        company_abbr +
+                        ' does not exist.')
+
+
 
     def add_project_prefix(self, project_name, company_abbr,
                            tw_project_id, project_date=None, project_number=None):
@@ -378,6 +408,28 @@ class TeamworkHandler(object):
         project_name = project_date + "-" + company_abbr + \
             "-" + str(project_number) + " " + project_name
         return project_name
+
+    def get_project_prefix(self, company_abbr,
+                            tw_project_id, project_date=None, project_number=None):
+        """Adds the project prefix to the project name
+
+        :param project_name: Project name
+        :param company_abbr: Company abbreviation
+        :param project_date: Project creation date
+        :param project_number: Project number
+        :return: Project Prefix
+        :rtype: str
+        """
+        if project_date is None:
+            project_date = datetime.datetime.now().strftime('%y%m')
+
+        if project_number is None:
+            project_number = self.get_project_number(
+                company_abbr, tw_project_id)
+
+        project_prefix = project_date + "-" + company_abbr + \
+            "-" + str(project_number)
+        return project_prefix
 
     def get_project_number(self, company_abbr, tw_project_id):
         """Assigns a company_job_id for the Teamwork project


### PR DESCRIPTION
Update Harvest look up to pass client parameter for better efficiency and less time out.
Also check to see if a job prefix exists in Harvest first before creating it to avoid duplicate jobs.